### PR TITLE
Remove with_items for apt and rpm module

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -36,27 +36,25 @@
 
 - name: Install Webserver Dependencies (1/2)
   apt:
-    name: "{{ item }}"
+    name:
+      - apache2
+      - libapache2-mod-perl2
+      - libapache2-mod-fcgid
+      - apt-transport-https
+      - liblasso-perl
     state: present
   when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
-  with_items:
-    - apache2
-    - libapache2-mod-perl2
-    - libapache2-mod-fcgid
-    - apt-transport-https
-    - liblasso-perl
 
 - name: Install Webserver Dependencies (2/2)
   apt:
-    name: "{{ item }}"
+    name: 
+      - nginx
+      - nginx-extras
+      - lemonldap-ng-fastcgi-server
+      - apt-transport-https
+      - liblasso-perl
     state: present
   when: lemonldap_webserver | default('apache') == 'nginx'
-  with_items:
-    - nginx
-    - nginx-extras
-    - lemonldap-ng-fastcgi-server
-    - apt-transport-https
-    - liblasso-perl
 
 - name: Enable Apache
   service:
@@ -74,8 +72,7 @@
 
 - name: Install LLNG
   apt:
-    name: "{{ item }}"
+    name: 
+      - lemonldap-ng
+      - lemonldap-ng-doc
     state: present
-  with_items:
-    - lemonldap-ng
-    - lemonldap-ng-doc

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -28,25 +28,23 @@
 
 - name: Install Webserver Dependencies (1/2)
   yum:
-    name: "{{ item }}"
+    name:
+      - httpd
+      - mod_perl
+      - mod_fcgid
+      - perl-LWP-Protocol-https
     state: present
     update_cache: yes
   when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
-  with_items:
-    - httpd
-    - mod_perl
-    - mod_fcgid
-    - perl-LWP-Protocol-https
 
 - name: Install Webserver Dependencies (2/2)
   yum:
-    name: "{{ item }}"
+    name:
+      - nginx
+      - lemonldap-ng-fastcgi-server
+      - perl-LWP-Protocol-https
     state: present
   when: lemonldap_webserver | default('apache') == 'nginx'
-  with_items:
-    - nginx
-    - lemonldap-ng-fastcgi-server
-    - perl-LWP-Protocol-https
 
 - name: Enable Apache
   service:
@@ -64,17 +62,15 @@
 
 - name: Install LLNG
   yum:
-    name: "{{ item }}"
+    name:
+      - lemonldap-ng
+      - lemonldap-ng-fr-doc
     state: present
-  with_items:
-    - lemonldap-ng
-    - lemonldap-ng-fr-doc
 
 - name: Install LLNG Nginx support
   yum:
-    name: "{{ item }}"
+    name: 
+      - lemonldap-ng-nginx
     state: present
-  with_items:
-    - lemonldap-ng-nginx
   when:
     - "lemonldap_webserver == 'nginx'"


### PR DESCRIPTION
Instead of calling apt with the legacy with_items, we directly use the new recommended way. So we call this module with the list under the name param.

We want to move away from those deprecation warnings : 
```
TASK [workteks.lemonldap : Install Webserver Dependencies (2/2)] ***************                                           
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via                                                      
squash_actions is deprecated. Instead of using a loop to supply multiple items                                              
and specifying `name: "{{ item }}"`, please use `name: ['nginx', 'nginx-                                                    
extras', 'lemonldap-ng-fastcgi-server', 'apt-transport-https', 'liblasso-                                                   
perl']` and remove the loop. This feature will be removed from ansible-base in                                             
version 2.11. Deprecation warnings can be disabled by setting                                                               
deprecation_warnings=False in ansible.cfg.   
```                    