### PR TITLE
Add first version of molecule test config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+---
+name: CI
+on: [push, pull_request, workflow_dispatch]
+
+defaults:
+  run:
+    working-directory: 'ansible-lemonldapng'
+
+jobs:
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'ansible-lemonldapng'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install yamllint
+
+      - name: Lint code.
+        run: |
+          yamllint .
+
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - centos7
+          - debian11
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'ansible-lemonldapng'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible molecule[docker] docker
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+
+ignore: |
+  .github/stale.yml
+  tests/*.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 lemonldap_gpg_pubkey_id: 81F18E7A
-lemonldap_do_soap: False
+lemonldap_do_soap: false
 lemonldap_domain: changeme.com
 lemonldap_webserver: nginx
 lemonldap_webserver_conf:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,7 @@
   service:
     name: llng-fastcgi-server
     state: restarted
-    enabled: yes
+    enabled: true
   when:
     - lemonldap_webserver == 'nginx'
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,28 +1,29 @@
 galaxy_info:
-  author: Clément Oudot (clement.oudot@worteks.com)
-  description: LLNG
-  company: Worteks
-  issue_tracker_url: https://github.com/worteks/ansible-lemonldapng/issues
-  license: MIT
-  min_ansible_version: 2.4
-  github_branch: master
-  platforms:
-   - name: CentOS
-     versions:
-     - all
-   - name: RedHat
-     versions:
-     - all
-   - name: Debian
-     versions:
-     - all
-   - name: Ubuntu
-     versions:
-     - all
-  galaxy_tags:
-    - authentication
-    - SSO
-    - SAML
-    - LemonLDAP-NG
-    - Web
+    author: Clément Oudot (clement.oudot@worteks.com)
+    description: LLNG
+    company: Worteks
+    issue_tracker_url: https://github.com/worteks/ansible-lemonldapng/issues
+    license: MIT
+    min_ansible_version: 2.4
+    github_branch: master
+    role_name: workteks.lemonldap
+    platforms:
+        - name: CentOS
+          versions:
+              - all
+        - name: RedHat
+          versions:
+              - all
+        - name: Debian
+          versions:
+              - all
+        - name: Ubuntu
+          versions:
+              - all
+    galaxy_tags:
+        - authentication
+        - SSO
+        - SAML
+        - LemonLDAP-NG
+        - Web
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
     author: Clément Oudot (clement.oudot@worteks.com)
     description: LLNG

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,4 +17,4 @@
   tasks:
     - name: "Include ansible-lemonldapng"
       include_role:
-        name: "ansible-lemonldapng"
+        name: "workteks.lemonldap"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    lemonldap_domain: example.ci
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+    - name: Install GPG
+      apt: 
+        name: gpg
+        state: present
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+  tasks:
+    - name: "Include ansible-lemonldapng"
+      include_role:
+        name: "ansible-lemonldapng"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,7 +9,7 @@
       when: ansible_os_family == 'Debian'
       changed_when: false
     - name: Install GPG
-      apt: 
+      apt:
         name: gpg
         state: present
       when: ansible_os_family == 'Debian'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    pre_build_image: true
+    networks:
+      - name: lemonldap
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - lint
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,22 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Verify web server is running
+    uri:
+      url: http://localhost/
+      status_code: 200
+      return_content: yes
+      headers:
+        Host: auth.example.ci
+    register: result_get_auth_portal
+  - name: Debug
+    debug:
+      msg: '{{ result_get_auth_portal }}'
+  - name: Check if LemonLDAP is present into response
+    assert:
+      that:
+        - "'LemonLDAP' in result_get_auth_portal.content"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -9,7 +9,7 @@
     uri:
       url: http://localhost/
       status_code: 200
-      return_content: yes
+      return_content: true
       headers:
         Host: auth.example.ci
     register: result_get_auth_portal

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -28,7 +28,7 @@
 
 - name: Refresh Packages Cache
   apt:
-    update_cache: yes
+    update_cache: true
   when:
     - llng_repo is defined
     - llng_repo.changed is defined
@@ -43,7 +43,7 @@
       - apt-transport-https
       - liblasso-perl
     state: present
-  when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
+  when: lemonldap_webserver | default('apache') in ['apache','httpd']
 
 - name: Install Webserver Dependencies (2/2)
   apt:
@@ -60,14 +60,14 @@
   service:
     name: apache2
     state: started
-    enabled: yes
+    enabled: true
   when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
 
 - name: Enable Nginx
   service:
     name: nginx
     state: started
-    enabled: yes
+    enabled: true
   when: lemonldap_webserver | default('apache') == 'nginx'
 
 - name: Install LLNG

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -47,7 +47,7 @@
 
 - name: Install Webserver Dependencies (2/2)
   apt:
-    name: 
+    name:
       - nginx
       - nginx-extras
       - lemonldap-ng-fastcgi-server
@@ -72,7 +72,7 @@
 
 - name: Install LLNG
   apt:
-    name: 
+    name:
       - lemonldap-ng
       - lemonldap-ng-doc
     state: present

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -34,7 +34,7 @@
       - mod_fcgid
       - perl-LWP-Protocol-https
     state: present
-    update_cache: yes
+    update_cache: true
   when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
 
 - name: Install Webserver Dependencies (2/2)
@@ -50,14 +50,14 @@
   service:
     name: httpd
     state: started
-    enabled: yes
+    enabled: true
   when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
 
 - name: Enable Nginx
   service:
     name: nginx
     state: started
-    enabled: yes
+    enabled: true
   when: lemonldap_webserver | default('apache') == 'nginx'
 
 - name: Install LLNG
@@ -69,7 +69,7 @@
 
 - name: Install LLNG Nginx support
   yum:
-    name: 
+    name:
       - lemonldap-ng-nginx
     state: present
   when:

--- a/tasks/set-domain.yml
+++ b/tasks/set-domain.yml
@@ -3,14 +3,14 @@
   find:
     paths: /etc/lemonldap-ng/
     patterns: "^.*?{{ lemonldap_webserver }}.*?\\.conf$"
-    use_regex: yes
+    use_regex: true
   register: lemonldap_webserver_conf_search_res
 
 - name: Find apache conf file to edit
   find:
     paths: /etc/httpd/conf.d/
     patterns: "^z-lemonldap-ng.*?\\.conf$"
-    use_regex: yes
+    use_regex: true
   register: lemonldap_apache_conf_search_res
 
 - name: Find nginx conf file to edit
@@ -23,7 +23,7 @@
   find:
     paths: /etc/lemonldap-ng/
     patterns: "^.*?\\.ini$"
-    use_regex: yes
+    use_regex: true
   register: lemonldap_ini_search_rest
 
 - name: Check LLNG Current Domain
@@ -37,7 +37,7 @@
     - "{{ lemonldap_apache_conf_search_res.files }}"
     - "{{ lemonldap_nginx_conf_search_res.files }}"
     - "{{ lemonldap_ini_search_rest.files }}"
-    - { 'path': '/var/lib/lemonldap-ng/conf/lmConf-1.json' }
+    - {'path': '/var/lib/lemonldap-ng/conf/lmConf-1.json'}
   notify:
     - Reload Webserver
     - Enable and reload lemonldap


### PR DESCRIPTION
Add a minimal config for molecule to test the LemonLDAP::NG on Debian
stable and CentOS 8. Currently those tests should be run by hand and are
not executed by any CI.