### PR TITLE
Replace pre-tasks by prepare to install gpg

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,16 +3,5 @@
   hosts: all
   vars:
     lemonldap_domain: example.ci
-  pre_tasks:
-    - name: Update apt cache.
-      apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-    - name: Install GPG
-      apt:
-        name: gpg
-        state: present
-      when: ansible_os_family == 'Debian'
-      changed_when: false
   roles:
     - worteks.lemonldap.install

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,11 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Update apt cache and install gpg
+      apt:
+        name: gpg
+        state: present
+        update_cache: true
+      when: ansible_os_family == 'Debian'


### PR DESCRIPTION
We use prepare.yml playbook to install gpg on Debian to avoid re-runing that (out off scope) tasks when testing our collection.