### PR TITLE
Fix ansible lint upstream

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
   gather_facts: true
   tasks:
     - name: Update apt cache and install gpg
-      apt:
+      ansible.builtin.apt:
         name: gpg
         state: present
         update_cache: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,7 +6,7 @@
   gather_facts: false
   tasks:
     - name: Verify web server is running
-      uri:
+      ansible.builtin.uri:
         url: http://localhost/
         status_code: 200
         return_content: true
@@ -14,9 +14,9 @@
           Host: auth.example.ci
       register: result_get_auth_portal
     - name: Debug
-      debug:
+      ansible.builtin.debug:
         msg: '{{ result_get_auth_portal }}'
     - name: Check if LemonLDAP is present into response
-      assert:
+      ansible.builtin.assert:
         that:
           - "'LemonLDAP' in result_get_auth_portal.content"

--- a/roles/install/handlers/main.yml
+++ b/roles/install/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Enable and reload lemonldap
-  service:
+  ansible.builtin.service:
     name: llng-fastcgi-server
     state: restarted
     enabled: true
@@ -8,7 +8,7 @@
     - lemonldap_webserver == 'nginx'
 
 - name: Debian Restart Apache
-  service:
+  ansible.builtin.service:
     name: apache2
     state: restarted
   listen: Reload Webserver
@@ -17,7 +17,7 @@
     - lemonldap_webserver in [ 'apache', 'httpd' ]
 
 - name: Redhat Restart Apache
-  service:
+  ansible.builtin.service:
     name: httpd
     state: restarted
   listen: Reload Webserver
@@ -26,7 +26,7 @@
     - lemonldap_webserver in [ 'apache', 'httpd' ]
 
 - name: Restart nginx
-  service:
+  ansible.builtin.service:
     name: nginx
     state: restarted
   listen: Reload Webserver

--- a/roles/install/tasks/config.yml
+++ b/roles/install/tasks/config.yml
@@ -1,2 +1,3 @@
 ---
-- include_tasks: set-domain.yml
+- name: Include_tasks set-domain.yml
+  ansible.builtin.include_tasks: set-domain.yml

--- a/roles/install/tasks/debian.yml
+++ b/roles/install/tasks/debian.yml
@@ -1,11 +1,11 @@
 ---
 - name: Install apt-transport-https
-  apt:
+  ansible.builtin.apt:
     name: apt-transport-https
     state: present
 
 - name: Install LLNG Repository KEY
-  copy:
+  ansible.builtin.copy:
     src: rpm-gpg-key-ow2
     dest: /tmp/gpg-key-ow2
     owner: root
@@ -13,12 +13,12 @@
     mode: 0644
 
 - name: Import LLNG GPG KEY
-  apt_key:
+  ansible.builtin.apt_key:
     file: /tmp/gpg-key-ow2
     state: present
 
 - name: Install LLNG Debian Repository
-  copy:
+  ansible.builtin.copy:
     src: debian_lemonldap-ng.list
     dest: /etc/apt/sources.list.d/lemonldap-ng.list
     owner: root
@@ -27,7 +27,7 @@
   register: llng_repo
 
 - name: Refresh Packages Cache
-  apt:
+  ansible.builtin.apt:
     update_cache: true
   when:
     - llng_repo is defined
@@ -35,7 +35,7 @@
     - llng_repo.changed
 
 - name: Install Webserver Dependencies (1/2)
-  apt:
+  ansible.builtin.apt:
     name:
       - apache2
       - libapache2-mod-perl2
@@ -46,7 +46,7 @@
   when: lemonldap_webserver | default('apache') in ['apache','httpd']
 
 - name: Install Webserver Dependencies (2/2)
-  apt:
+  ansible.builtin.apt:
     name:
       - nginx
       - nginx-extras
@@ -57,21 +57,21 @@
   when: lemonldap_webserver | default('apache') == 'nginx'
 
 - name: Enable Apache
-  service:
+  ansible.builtin.service:
     name: apache2
     state: started
     enabled: true
   when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
 
 - name: Enable Nginx
-  service:
+  ansible.builtin.service:
     name: nginx
     state: started
     enabled: true
   when: lemonldap_webserver | default('apache') == 'nginx'
 
 - name: Install LLNG
-  apt:
+  ansible.builtin.apt:
     name:
       - lemonldap-ng
       - lemonldap-ng-doc

--- a/roles/install/tasks/install.yml
+++ b/roles/install/tasks/install.yml
@@ -1,5 +1,7 @@
 ---
-- include_tasks: redhat.yml
+- name: Include_tasks redhat.yml
+  ansible.builtin.include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"
-- include_tasks: debian.yml
+- name: Include_tasks debian.yml
+  ansible.builtin.include_tasks: debian.yml
   when: ansible_os_family == "Debian"

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -1,3 +1,5 @@
 ---
-- include_tasks: install.yml
-- include_tasks: config.yml
+- name: Include_tasks install.yml
+  ansible.builtin.include_tasks: install.yml
+- name: Include_tasks config.yml
+  ansible.builtin.include_tasks: config.yml

--- a/roles/install/tasks/redhat.yml
+++ b/roles/install/tasks/redhat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install LLNG Repository KEY
-  copy:
+  ansible.builtin.copy:
     src: rpm-gpg-key-ow2
     dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-OW2
     owner: root
@@ -8,12 +8,12 @@
     mode: 0644
 
 - name: Import LLNG GPG KEY
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-OW2
     state: present
 
 - name: Install epel-release
-  yum:
+  ansible.builtin.yum:
     name: epel-release
     state: present
 
@@ -28,7 +28,7 @@
   register: check_powertools
   changed_when: false
   ansible.builtin.command:
-    cmd: dnf repolist --enabled {{powertools_repo }}
+    cmd: dnf repolist --enabled {{ powertools_repo }}
 
 - name: Enable powertools if not already enabled
   when: (check_powertools.stdout_lines | length) == 0
@@ -37,7 +37,7 @@
     cmd: dnf -y config-manager --set-enabled {{ powertools_repo }}
 
 - name: Install LLNG Enterprise Linux Repository
-  copy:
+  ansible.builtin.copy:
     src: redhat_lemonldap-ng.repo
     dest: /etc/yum.repos.d/lemonldap-ng.repo
     owner: root
@@ -46,7 +46,7 @@
   register: llng_repo
 
 - name: Install Webserver Dependencies (1/2)
-  yum:
+  ansible.builtin.yum:
     name:
       - httpd
       - mod_perl
@@ -57,7 +57,7 @@
   when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
 
 - name: Install Webserver Dependencies (2/2)
-  yum:
+  ansible.builtin.yum:
     name:
       - nginx
       - lemonldap-ng-fastcgi-server
@@ -66,28 +66,28 @@
   when: lemonldap_webserver | default('apache') == 'nginx'
 
 - name: Enable Apache
-  service:
+  ansible.builtin.service:
     name: httpd
     state: started
     enabled: true
   when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
 
 - name: Enable Nginx
-  service:
+  ansible.builtin.service:
     name: nginx
     state: started
     enabled: true
   when: lemonldap_webserver | default('apache') == 'nginx'
 
 - name: Install LLNG
-  yum:
+  ansible.builtin.yum:
     name:
       - lemonldap-ng
       - lemonldap-ng-doc
     state: present
 
 - name: Install LLNG Nginx support
-  yum:
+  ansible.builtin.yum:
     name:
       - lemonldap-ng-nginx
     state: present

--- a/roles/install/tasks/set-domain.yml
+++ b/roles/install/tasks/set-domain.yml
@@ -1,33 +1,33 @@
 ---
 - name: Find conf file to edit
-  find:
+  ansible.builtin.find:
     paths: /etc/lemonldap-ng/
     patterns: "^.*?{{ lemonldap_webserver }}.*?\\.conf$"
     use_regex: true
   register: lemonldap_webserver_conf_search_res
 
 - name: Find apache conf file to edit
-  find:
+  ansible.builtin.find:
     paths: /etc/httpd/conf.d/
     patterns: "^z-lemonldap-ng.*?\\.conf$"
     use_regex: true
   register: lemonldap_apache_conf_search_res
 
 - name: Find nginx conf file to edit
-  find:
+  ansible.builtin.find:
     paths: /etc/nginx/conf.d/
     patterns: "*-nginx.conf"
   register: lemonldap_nginx_conf_search_res
 
 - name: Find ini file to edit
-  find:
+  ansible.builtin.find:
     paths: /etc/lemonldap-ng/
     patterns: "^.*?\\.ini$"
     use_regex: true
   register: lemonldap_ini_search_rest
 
 - name: Check LLNG Current Domain
-  replace:
+  ansible.builtin.replace:
     path: "{{ item.path }}"
     regexp: 'example\.com'
     replace: '{{ lemonldap_domain }}'
@@ -42,8 +42,8 @@
     - Reload Webserver
     - Enable and reload lemonldap
 
-- name: symlink webserver config file
-  file:
+- name: Symlink webserver config file
+  ansible.builtin.file:
     src: "/etc/lemonldap-ng/{{ item }}.conf"
     dest: "/etc/nginx/sites-enabled/{{ item }}.conf"
     state: link
@@ -58,7 +58,7 @@
   notify: Reload Webserver
 
 - name: Enable apache lemonldap config
-  command: "a2ensite {{ item }}"
+  ansible.builtin.command: "a2ensite {{ item }}"
   register: res_a2ensite
   changed_when: "'already enabled' not in res_a2ensite.stdout"
   with_items:
@@ -71,7 +71,7 @@
   notify: Reload Webserver
 
 - name: Enable apache module required by lemonldap config
-  command: "a2enmod {{ item }}"
+  ansible.builtin.command: "a2enmod {{ item }}"
   register: res_a2enmod
   changed_when: "'already enabled' not in res_a2enmod.stdout"
   with_items:

--- a/roles/install/tests/test.yml
+++ b/roles/install/tests/test.yml
@@ -1,16 +1,20 @@
-- hosts: lemon
+- name: Execute roles
+  hosts: lemon
   roles:
-    - ../ansible-lemonldapng/
+    - worteks.lemonldap.install
 
-- hosts: lemon
+- name: Run login tasks
+  hosts: lemon
   tasks:
-    - uri:
+    - name: Get login token
+      ansible.builtin.uri:
         url: http://{{ ansible_default_ipv4.address }}/
         headers:
             Host: "auth.{{ lemonldap_domain }}"
         return_content: yes
       register: loginform
-    - uri:
+    - name: Login to create cookie
+      ansible.builtin.uri:
         url: http://{{ ansible_default_ipv4.address }}/
         method: POST
         headers:
@@ -23,5 +27,6 @@
             token: "{{ loginform.content | regex_search('name=\"token\" value=\"([^\"]*)\"', '\\1') }}"
       register: login_post
 
-    - assert:
+    - name: Assert login cookie
+      ansible.builtin.assert:
         that: "'lemonldap=' in login_post.set_cookie"


### PR DESCRIPTION
See #15.
These are mostly trivial fixes of what ansible-lint is complaining about. There are some more in galaxy.yml and meta/main.yml which I like to tackle separately afterwards.