### PR TITLE
Fix Ansible lint in galaxy.yml and meta

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,8 @@
+---
+releases:
+  1.0.0-beta:
+    release_date: '2024-06-01'
+    changes:
+      release_summary: Preparation for the first official release
+      major_changes:
+        - Migration from role to collection

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: worteks
 name: lemonldap
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.1
+version: 1.0.0-beta
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -40,6 +40,8 @@ license_file: ''
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
 tags:
+  - linux
+  - security
   - authentication
   - SSO
   - SAML

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.12.0"

--- a/roles/install/meta/main.yml
+++ b/roles/install/meta/main.yml
@@ -5,14 +5,10 @@ galaxy_info:
     company: Worteks
     issue_tracker_url: https://github.com/worteks/ansible-lemonldapng/issues
     license: MIT
-    min_ansible_version: 2.4
+    min_ansible_version: "2.12"
     github_branch: master
-    role_name: workteks.lemonldap
     platforms:
-        - name: CentOS
-          versions:
-              - all
-        - name: RedHat
+        - name: EL
           versions:
               - all
         - name: Debian
@@ -23,8 +19,8 @@ galaxy_info:
               - all
     galaxy_tags:
         - authentication
-        - SSO
-        - SAML
-        - LemonLDAP-NG
-        - Web
+        - sso
+        - saml
+        - lemonldapng
+        - web
 dependencies: []


### PR DESCRIPTION
This PR will fix the remaining ansible-lint complains.

Summary:
- minimum allowed version is 1.0.0; use 1.0.0-beta until officially released
- role name can be omitted after migration into collection
- provide minimal changelog (required)
- platform is EL for CentOS and RedHat
- use reasonable recent ansible 2.12 as minimum version
- use only allowed characters for galaxy tags

Tested with: ansible-lint 6.13.1 using ansible 2.14.3