### PR TITLE
Remove contradicting default value for lemonldap_webserver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: 3.14
 
       - name: Install test dependencies.
-        run: pip3.14 install ansible ansible-core=>2.20.0 molecule docker molecule-plugins
+        run: pip3.14 install ansible ansible-core>=2.20.0 molecule docker molecule-plugins
 
       - name: Build the collection
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v2
         with:
-          python-version: 3.x
+          python-version: 3.14
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-core>=2.20.0 molecule docker molecule-plugins
+        run: pip3.14 install ansible ansible-core=>2.20.0 molecule docker molecule-plugins
 
       - name: Build the collection
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: 3.x
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-core==2.16.8 molecule docker molecule-plugins
+        run: pip3 install ansible ansible-core>=2.20.0 molecule docker molecule-plugins
 
       - name: Build the collection
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v2
         with:
-          python-version: 3.14
+          python-version: 3.13
 
       - name: Install test dependencies.
-        run: pip3.14 install ansible ansible-core>=2.20.0 molecule docker molecule-plugins
+        run: pip3 install ansible ansible-core molecule docker molecule-plugins
 
       - name: Build the collection
         run: |

--- a/roles/install/tasks/debian.yml
+++ b/roles/install/tasks/debian.yml
@@ -37,11 +37,11 @@
     name: apache2
     state: started
     enabled: true
-  when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
+  when: lemonldap_webserver in [ 'apache', 'httpd' ]
 
 - name: Enable Nginx
   ansible.builtin.service:
     name: nginx
     state: started
     enabled: true
-  when: lemonldap_webserver | default('apache') == 'nginx'
+  when: lemonldap_webserver == 'nginx'

--- a/roles/install/tasks/redhat.yml
+++ b/roles/install/tasks/redhat.yml
@@ -58,11 +58,11 @@
     name: httpd
     state: started
     enabled: true
-  when: lemonldap_webserver | default('apache') in [ 'apache', 'httpd' ]
+  when: lemonldap_webserver in [ 'apache', 'httpd' ]
 
 - name: Enable Nginx
   ansible.builtin.service:
     name: nginx
     state: started
     enabled: true
-  when: lemonldap_webserver | default('apache') == 'nginx'
+  when: lemonldap_webserver == 'nginx'


### PR DESCRIPTION
The `lemonldap_webserver` variable has a default value set in [defaults/main.yml](https://github.com/Worteks/ansible-lemonldapng/blob/361293351ef3df71f6003fb9fa6fb399afa7632d/roles/install/defaults/main.yml#L5).

Still, when using it in `debian.yml` and in `redhat.yml`, another (and distinct) default value is provided. The first one is used, si this other default value is never used.

This PR removes the explicit default in debian.yml and redhat.yml in favor of the default in defaults/main.yml.